### PR TITLE
Producers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,18 @@ exactly once. We never bind some `m a` twice.
 
 Linear types lets us enforce this.
 
+## Design
+
+Effectively, all of the design boils down to changing the `m` in
+`Stream f m r` to have a `Control.Monad.Linear.Monad` instance.
+We do this for as many API functions as we can.
+
+This change requires the `f` to have a `Control.Monad.Linear.Functor` instance
+and a `Control.Monad` instance for any `Stream f m` with appropriate `m` and `f`.
+In general, all changes are necessarily implied from just changing the `m`.
+
+## Conventions
+
+ * We use `Text` in place of `String`
+
 [streaming]: https://github.com/haskell-streaming/streaming

--- a/linear-streams.cabal
+++ b/linear-streams.cabal
@@ -25,7 +25,8 @@ library
     Streaming.Type
   build-depends:
     base >= 4.7 && < 5,
-    linear-base
+    linear-base,
+    text
   default-language: Haskell2010
 
 test-suite examples

--- a/src/Streaming/Produce.hs
+++ b/src/Streaming/Produce.hs
@@ -1,10 +1,14 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | This module provides all functions which produce a
 -- 'Stream (Of a) m r' from some given non-stream inputs.
 module Streaming.Produce
-  ( {- yield
-  , each
+  ( yield
   , each'
   , unfoldr
   , stdinLn
@@ -16,14 +20,154 @@ module Streaming.Produce
   , repeat
   , repeatM
   , replicate
+  , replicateM
   , untilRight
   , cycle
-  , replicateM
   , enumFrom
   , enumFromThen
-  , seconds
-  -}
   ) where
 
+import Streaming.Type
+import Streaming.Process
+import Prelude.Linear (($), (&))
+import Prelude (Either(..), Read, Bool(..), FilePath,
+               Num(..), Int, otherwise, Eq(..), Ord(..), (.))
+import qualified Prelude
+import qualified Control.Monad.Linear as Control
+import Control.Monad.Linear.Builder (BuilderType(..), monadBuilder)
+import Data.Unrestricted.Linear
+import System.IO.Linear
+import System.IO.Resource
+import qualified System.IO as System
+import Text.Read (readMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import GHC.Stack
 
+
+-- # The Stream Constructors
+-------------------------------------------------------------------------------
+
+yield :: Control.Monad m => a -> Stream (Of a) m ()
+yield x = Step $ x :> Return ()
+
+each' :: Control.Monad m => [a] -> Stream (Of a) m ()
+each' xs = Prelude.foldr (\a stream -> Step $ a :> stream) (Return ()) xs
+
+unfoldr :: Control.Monad m =>
+  (s #-> m (Either r (Unrestricted a, s))) -> s #-> Stream (Of a) m r
+unfoldr step s = Effect $ step s Control.>>= \case
+  Left r -> return $ Return r
+  Right (Unrestricted a,s') -> return $ Step $ a :> unfoldr step s'
+  where
+    Builder{..} = monadBuilder
+
+-- Note: we use System.IO.Linear.IO since our IO needs to
+-- have a Control.Monad instance
+stdinLn :: Stream (Of Text) IO ()
+stdinLn = do
+  Unrestricted line <- Control.lift $ fromSystemIOU Text.getLine
+  yield line
+  stdinLn
+  where
+    Builder{..} = monadBuilder
+
+readLn :: Read a => Stream (Of a) IO ()
+readLn = mapMaybe (readMaybe . Text.unpack) stdinLn
+
+-- Note: we use the RIO monad from linear base to enforce
+-- the protocol of file handles and file I/O
+fromHandle :: Handle #-> Stream (Of Text) RIO ()
+fromHandle h = do
+  (Unrestricted isEOF, h') <- Control.lift $ hIsEOF h
+  case isEOF of
+    True -> do
+      Control.lift $ hClose h'
+      return ()
+    False -> do
+      (Unrestricted text, h'') <- Control.lift $ hGetLine h'
+      yield text
+      fromHandle h''
+  where
+    Builder{..} = monadBuilder
+
+readFile :: FilePath -> Stream (Of Text) RIO ()
+readFile path = do
+  handle <- Control.lift $ openFile path System.ReadMode
+  fromHandle handle
+  where
+    Builder{..} = monadBuilder
+
+iterate :: Control.Monad m => (a -> a) -> a -> Stream (Of a) m r
+iterate step x = Effect $ return $ Step $ x :> iterate step (step x)
+  where
+    Builder{..} = monadBuilder
+
+iterateM :: Control.Monad m =>
+  (a -> m (Unrestricted a)) -> m (Unrestricted a) #-> Stream (Of a) m r
+iterateM stepM mx = Effect $ do
+  Unrestricted x <- mx
+  return $ Step $ x :> iterateM stepM (stepM x)
+  where
+    Builder{..} = monadBuilder
+
+repeat :: Control.Monad m => a -> Stream (Of a) m r
+repeat = iterate Prelude.id
+
+repeatM :: Control.Monad m => m (Unrestricted a) -> Stream (Of a) m r
+repeatM ma = Effect $ do
+  Unrestricted a <- ma
+  return $ Step $ a :> repeatM ma
+  where
+    Builder{..} = monadBuilder
+
+replicate :: (HasCallStack, Control.Monad m) => Int -> a -> Stream (Of a) m ()
+replicate n a
+  | n < 0 = Prelude.error "Cannot replicate a stream of negative length"
+  | n == 0 = Return ()
+  | otherwise = Effect $ Control.return $ Step $ a :> replicate (n-1) a
+
+replicateM :: Control.Monad m =>
+  Int -> m (Unrestricted a) -> Stream (Of a) m ()
+replicateM n ma
+  | n < 0 = Prelude.error "Cannot replicate a stream of negative length"
+  | n == 0 = Return ()
+  | otherwise = Effect $ do
+    Unrestricted a <- ma
+    return $ Step $ a :> (replicateM (n-1) ma)
+    where
+      Builder{..} = monadBuilder
+
+untilRight :: Control.Monad m =>
+  m (Either (Unrestricted a) r) -> Stream (Of a) m r
+untilRight mEither = Effect $ do
+  either <- mEither
+  either & \case
+    Left (Unrestricted a) ->
+      return $ Step $ a :> (untilRight mEither)
+    Right r -> return $ Return r
+  where
+    Builder{..} = monadBuilder
+
+-- | 'cycle' repeats a linear stream by running through it
+-- from start to end indefinitely. To do so, it must use an
+-- unrestricted arrow following the stream argument.
+cycle :: (Control.Monad m, Control.Functor f, Consumable r) =>
+  Stream f m r -> Stream f m r
+cycle s = do
+  r <- s
+  lseq r $ cycle s
+  where
+  Builder{..} = monadBuilder
+
+enumFrom :: (Control.Monad m, Prelude.Enum n) => n -> Stream (Of n) m r
+enumFrom x = iterate Prelude.succ x
+
+enumFromThen ::
+  (Control.Monad m, Prelude.Enum a) => a -> a -> Stream (Of a) m r
+enumFromThen first second =
+  map Prelude.toEnum $ iterate (+ diff) (Prelude.fromEnum first)
+  where
+    diff = Prelude.fromEnum first - Prelude.fromEnum second
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/tweag/linear-base.git
-    commit: 627bf381a94473aca89c9a5ce98c69ceb7a22266
+    commit: c21edd4091c25873624e1e0246d81e5036fb174f
 
 nix:
   enable: true


### PR DESCRIPTION
This PR adds all sensible stream constructors from `Streaming.Prelude`. Note that this uses the [linear-stream-support](https://github.com/tweag/linear-base/tree/linear-stream-support) branch of linear base.

# Remark

The [existing work](https://github.com/m0ar/safe-streaming/blob/master/src/Streaming/Prelude.hs) is often very incorrect and would not pass the current type checker. So far, 10 % of what I've read is outdated and at least 70% is flat out wrong as written. As a result, I've decided to just re-write this work glancing at what's already been written. (Not trying to be harsh, but I'm a bit annoyed with the state of the code.)

Example:

In the function below, the `a` must be used linearly after it's taken out of `ma` but it can't be. The type is wrong and the code should not typecheck.

```haskell
-- | Iterate a monadic function from a seed value, streaming the results forever
iterateM :: forall a m r. LMonad m
         => (a -> m a) -> m a ⊸ Stream (LOf a) m r
iterateM f = loop where
  loop :: m a ⊸ Stream (LOf a) m r
  loop ma = Effect $ do
    a <- ma
    return $ Step $ a :> loop (f a)
{-# INLINABLE iterateM #-}
```

# Questions

- Should `fromHandle` consume the `Handle` or return it?
- I don't think `cycle` can ever be linear. Is this right?
- Should we have `seconds`? If so, what does linear base need to implement this easily?

