### PR TITLE
Smaller modules like Interop, Many and Pair

### DIFF
--- a/linear-streams.cabal
+++ b/linear-streams.cabal
@@ -19,6 +19,7 @@ library
     Streaming.Prelude
   other-modules:
     Streaming.Consume
+    Streaming.Interop
     Streaming.Many
     Streaming.Process
     Streaming.Produce
@@ -26,7 +27,8 @@ library
   build-depends:
     base >= 4.7 && < 5,
     linear-base,
-    text
+    text,
+    containers
   default-language: Haskell2010
 
 test-suite examples

--- a/src/Streaming/Interop.hs
+++ b/src/Streaming/Interop.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- | This module contains functions for interoperating with other
+-- streaming libraries.
+module Streaming.Interop
+  ( reread
+  ) where
+
+import Streaming.Type
+import Streaming.Produce
+import Data.Unrestricted.Linear
+import Prelude.Linear (($), (&))
+import Prelude (Maybe(..))
+import qualified Control.Monad.Linear as Control
+import Control.Monad.Linear.Builder (BuilderType(..), monadBuilder)
+
+{-| Read an @IORef (Maybe a)@ or a similar device until it reads @Nothing@.
+    @reread@ provides convenient exit from the @io-streams@ library
+
+> reread readIORef    :: IORef (Maybe a) -> Stream (Of a) IO ()
+> reread Streams.read :: System.IO.Streams.InputStream a -> Stream (Of a) IO ()
+-}
+reread :: Control.Monad m =>
+  (s -> m (Unrestricted (Maybe a))) -> s -> Stream (Of a) m ()
+reread f s = Effect $ do
+  Unrestricted maybeA <- f s
+  case maybeA of
+    Nothing -> return $ Return ()
+    Just a -> return $ (yield a >> reread f s)
+  where
+    Builder{..} = monadBuilder
+

--- a/src/Streaming/Many.hs
+++ b/src/Streaming/Many.hs
@@ -1,19 +1,78 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE LinearTypes #-}
+{-# LANGUAGE RebindableSyntax #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | This module contains all functions that do something with
 -- multiple streams as input or output. This includes combining
 -- streams, splitting a stream, etc.
 module Streaming.Many
   (
-  -- * Zips and unzips
-  {-
-  , zip
-  , zipWith
-  , zip3
-  , zipWith3
-  , unzip
-  -}
+  -- * Unzip
+    unzip
+  -- * Merging
+  , merge
+  , mergeOn
+  , mergeBy
   ) where
 
+import Streaming.Type
+import Streaming.Consume
+import Prelude (undefined, Bool(..), Either(..), Ord(..), Ordering(..), (.))
+import Prelude.Linear (($), (&))
+import qualified Prelude.Linear
+import qualified Prelude.Linear as Linear
+import qualified Control.Monad.Linear as Control
+import Control.Monad.Linear.Builder (BuilderType(..), monadBuilder)
 
+
+-- # Unzip
+-------------------------------------------------------------------------------
+
+unzip :: Control.Monad m =>
+  Stream (Of (a, b)) m r #-> Stream (Of a) (Stream (Of b) m) r
+unzip = loop
+  where
+  Builder{..} = monadBuilder
+  loop :: Control.Monad m =>
+    Stream (Of (a, b)) m r #-> Stream (Of a) (Stream (Of b) m) r
+  loop stream = stream & \case
+    Return r -> Return r
+    Effect m -> Effect $ Control.fmap loop $ Control.lift m
+    Step ((a,b):> rest) -> Step (a :> Effect (Step (b :> Return (loop rest))))
+
+
+-- # Merging
+-------------------------------------------------------------------------------
+
+merge :: (Control.Monad m, Ord a) =>
+  Stream (Of a) m r #-> Stream (Of a) m s #-> Stream (Of a) m (r,s)
+merge = mergeBy compare
+
+mergeOn :: (Control.Monad m, Ord b) =>
+  (a -> b) ->
+  Stream (Of a) m r #->
+  Stream (Of a) m s #->
+  Stream (Of a) m (r,s)
+mergeOn f = mergeBy (\x y -> compare (f x) (f y))
+
+mergeBy :: Control.Monad m =>
+  (a -> a -> Ordering) ->
+  Stream (Of a) m r #->
+  Stream (Of a) m s #->
+  Stream (Of a) m (r,s)
+mergeBy comp s1 s2 = s1 & \case
+  Return r -> Effect $ effects s2 >>= \s -> return $ Return (r, s)
+  Effect ms -> Effect $
+    ms >>= \s1' -> return $ mergeBy comp s1' s2
+  Step (a :> as) -> s2 & \case
+    Return s -> Effect $ effects as >>= \r -> return $ Return (r, s)
+    Effect ms -> Effect $
+      ms >>= \s2' -> return $ mergeBy comp (Step (a :> as)) s2'
+    Step (b :> bs) -> case comp a b of
+      LT -> Step (a :> Step (b :> mergeBy comp as bs))
+      _ -> Step (b :> Step (a :> mergeBy comp as bs))
+  where
+    Builder{..} = monadBuilder
 

--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -2,6 +2,7 @@
 
 module Streaming.Prelude
   ( module Streaming.Consume
+  , module Streaming.Interop
   , module Streaming.Many
   , module Streaming.Process
   , module Streaming.Produce
@@ -9,6 +10,7 @@ module Streaming.Prelude
   ) where
 
 import Streaming.Consume
+import Streaming.Interop
 import Streaming.Many
 import Streaming.Process
 import Streaming.Produce

--- a/src/Streaming/Process.hs
+++ b/src/Streaming/Process.hs
@@ -7,8 +7,7 @@
 -- stream and produce one output stream. These are functions that
 -- process a single stream.
 module Streaming.Process
-  ( mapMaybe
-  , map
+  (
   -- * Stream processors
   -- ** Splitting and inspecting streams of elements
     next


### PR DESCRIPTION
This PR implements a few smaller modules: `Interop.hs`, `Pair.hs` and `Many.hs`. The first two are standard utilities that were ported in a straightforward manner. 

The last module contains streaming functions that take many streams as input and/or return many streams as output. This includes `merge` and `zip`. I've chosen to implement some `zip` functions that exhaust the remainders to keep the API looking close to that of the original. I'm not sure if a better design would have been to return the remainders and leave exhausting the rest of the streams to the user. Perhaps doing `zip` properly is something that might be better to just revisit after we have a reasonable design for affine streams. So ... should I remove, modify or keep these `zip` functions as they are?