### PR TITLE
First half of trivially copying documentation and optimizations

### DIFF
--- a/src/Streaming/Consume.hs
+++ b/src/Streaming/Consume.hs
@@ -8,7 +8,7 @@
 -- | This module provides all functions that take input streams
 -- but do not return output streams.
 module Streaming.Consume
-  ( -- * Consuming streams of elements
+  ( -- * Consuming 'Stream's of elements
   -- ** IO Consumers
     stdoutLn
   , stdoutLn'

--- a/src/Streaming/Interop.hs
+++ b/src/Streaming/Interop.hs
@@ -6,7 +6,8 @@
 -- | This module contains functions for interoperating with other
 -- streaming libraries.
 module Streaming.Interop
-  ( reread
+  ( -- * Interoperating with other streaming libraries
+    reread
   ) where
 
 import Streaming.Type
@@ -25,11 +26,16 @@ import Control.Monad.Linear.Builder (BuilderType(..), monadBuilder)
 -}
 reread :: Control.Monad m =>
   (s -> m (Unrestricted (Maybe a))) -> s -> Stream (Of a) m ()
-reread f s = Effect $ do
-  Unrestricted maybeA <- f s
-  case maybeA of
-    Nothing -> return $ Return ()
-    Just a -> return $ (yield a >> reread f s)
+reread f s = reread' f s
   where
     Builder{..} = monadBuilder
+
+    reread' :: Control.Monad m =>
+      (s -> m (Unrestricted (Maybe a))) -> s -> Stream (Of a) m ()
+    reread' f s = Effect $ do
+      Unrestricted maybeA <- f s
+      case maybeA of
+        Nothing -> return $ Return ()
+        Just a -> return $ (yield a >> reread f s)
+{-# INLINABLE reread #-}
 

--- a/src/Streaming/Many.hs
+++ b/src/Streaming/Many.hs
@@ -9,9 +9,11 @@
 -- streams, splitting a stream, etc.
 module Streaming.Many
   (
-  -- * Unzip
+  -- * Operations that use or return multiple 'Stream's
+  -- ** Unzip
     unzip
-  -- * Merging
+  -- ** Merging
+  -- $ merging
   , merge
   , mergeOn
   , mergeBy
@@ -30,6 +32,59 @@ import Control.Monad.Linear.Builder (BuilderType(..), monadBuilder)
 -- # Unzip
 -------------------------------------------------------------------------------
 
+{-| The type
+
+> Data.List.unzip     :: [(a,b)] -> ([a],[b])
+
+   might lead us to expect
+
+> Streaming.unzip :: Stream (Of (a,b)) m r -> Stream (Of a) m (Stream (Of b) m r)
+
+   which would not stream, since it would have to accumulate the second stream (of @b@s).
+   Of course, @Data.List@ 'Data.List.unzip' doesn't stream either.
+
+   This @unzip@ does
+   stream, though of course you can spoil this by using e.g. 'toList':
+
+>>> let xs = Prelude.map (\x -> (x, Prelude.show x)) [1..5 :: Int]
+
+>>> S.toList $ S.toList $ S.unzip (S.each' xs)
+["1","2","3","4","5"] :> ([1,2,3,4,5] :> ())
+
+>>> Prelude.unzip xs
+([1,2,3,4,5],["1","2","3","4","5"])
+
+    Note the difference of order in the results. It may be of some use to think why.
+    The first application of 'toList' was applied to a stream of integers:
+
+>>> :t S.unzip $ S.each' xs
+S.unzip $ S.each' xs :: Control.Monad m => Stream (Of Int) (Stream (Of String) m) ()
+
+    Like any fold, 'toList' takes no notice of the monad of effects.
+
+> toList :: Control.Monad m => Stream (Of a) m r #-> m (Of [a] r)
+
+    In the case at hand (since I am in @ghci@) @m = Stream (Of String) IO@.
+    So when I apply 'toList', I exhaust that stream of integers, folding
+    it into a list:
+
+>>> :t S.toList $ S.unzip $ S.each' xs
+S.toList $ S.unzip $ S.each' xs
+  :: Control.Monad m => Stream (Of String) m (Of [Int] ())
+
+    When I apply 'toList' to /this/, I reduce everything to an ordinary action in @IO@,
+    and return a list of strings:
+
+>>> S.toList $ S.toList $ S.unzip (S.each' xs)
+["1","2","3","4","5"] :> ([1,2,3,4,5] :> ())
+
+'unzip' can be considered a special case of either 'unzips' or 'expand':
+
+@
+  unzip = 'unzips' . 'maps' (\((a,b) :> x) -> Compose (a :> b :> x))
+  unzip = 'expand' $ \p ((a,b) :> abs) -> b :> p (a :> abs)
+@
+-}
 unzip :: Control.Monad m =>
   Stream (Of (a, b)) m r #-> Stream (Of a) (Stream (Of b) m) r
 unzip = loop
@@ -41,38 +96,76 @@ unzip = loop
     Return r -> Return r
     Effect m -> Effect $ Control.fmap loop $ Control.lift m
     Step ((a,b):> rest) -> Step (a :> Effect (Step (b :> Return (loop rest))))
+{-# INLINABLE unzip #-}
 
 
 -- # Merging
 -------------------------------------------------------------------------------
 
+{- $merging
+   These functions combine two sorted streams of orderable elements
+   into one sorted stream. The elements of the merged stream are
+   guaranteed to be in a sorted order if the two input streams are
+   also sorted.
+
+   The merge operation is /left-biased/: when merging two elements
+   that compare as equal, the left element is chosen first.
+-}
+
+{- | Merge two streams of elements ordered with their 'Ord' instance.
+
+   The return values of both streams are returned.
+
+>>> S.print $ merge (each [1,3,5]) (each [2,4])
+1
+2
+3
+4
+5
+((), ())
+
+-}
 merge :: (Control.Monad m, Ord a) =>
   Stream (Of a) m r #-> Stream (Of a) m s #-> Stream (Of a) m (r,s)
 merge = mergeBy compare
+{-# INLINE merge #-}
 
+{- | Merge two streams, ordering them by applying the given function to
+   each element before comparing.
+
+   The return values of both streams are returned.
+-}
 mergeOn :: (Control.Monad m, Ord b) =>
   (a -> b) ->
   Stream (Of a) m r #->
   Stream (Of a) m s #->
   Stream (Of a) m (r,s)
 mergeOn f = mergeBy (\x y -> compare (f x) (f y))
+{-# INLINE mergeOn #-}
 
-mergeBy :: Control.Monad m =>
+{- | Merge two streams, ordering the elements using the given comparison function.
+
+   The return values of both streams are returned.
+-}
+mergeBy :: forall m a r s . Control.Monad m =>
   (a -> a -> Ordering) ->
   Stream (Of a) m r #->
   Stream (Of a) m s #->
   Stream (Of a) m (r,s)
-mergeBy comp s1 s2 = s1 & \case
-  Return r -> Effect $ effects s2 >>= \s -> return $ Return (r, s)
-  Effect ms -> Effect $
-    ms >>= \s1' -> return $ mergeBy comp s1' s2
-  Step (a :> as) -> s2 & \case
-    Return s -> Effect $ effects as >>= \r -> return $ Return (r, s)
-    Effect ms -> Effect $
-      ms >>= \s2' -> return $ mergeBy comp (Step (a :> as)) s2'
-    Step (b :> bs) -> case comp a b of
-      LT -> Step (a :> Step (b :> mergeBy comp as bs))
-      _ -> Step (b :> Step (a :> mergeBy comp as bs))
+mergeBy comp s1 s2 = loop s1 s2
   where
     Builder{..} = monadBuilder
+    loop :: Stream (Of a) m r #-> Stream (Of a) m s #-> Stream (Of a) m (r,s)
+    loop s1 s2 = s1 & \case
+      Return r -> Effect $ effects s2 >>= \s -> return $ Return (r, s)
+      Effect ms -> Effect $
+        ms >>= \s1' -> return $ mergeBy comp s1' s2
+      Step (a :> as) -> s2 & \case
+        Return s -> Effect $ effects as >>= \r -> return $ Return (r, s)
+        Effect ms -> Effect $
+          ms >>= \s2' -> return $ mergeBy comp (Step (a :> as)) s2'
+        Step (b :> bs) -> case comp a b of
+          LT -> Step (a :> Step (b :> mergeBy comp as bs))
+          _ -> Step (b :> Step (a :> mergeBy comp as bs))
+{-# INLINABLE mergeBy #-}
 

--- a/src/Streaming/Process.hs
+++ b/src/Streaming/Process.hs
@@ -32,10 +32,10 @@ module Streaming.Process
   , sumToEither
   , sumToCompose
   , composeToSum
-  -- * Partitions
+  -- ** Partitions
   , partitionEithers
   , partition
-  -- * Maybes
+  -- ** Maybes
   , catMaybes
   , mapMaybe
   , mapMaybeM

--- a/src/Streaming/Produce.hs
+++ b/src/Streaming/Produce.hs
@@ -8,7 +8,8 @@
 -- | This module provides all functions which produce a
 -- 'Stream (Of a) m r' from some given non-stream inputs.
 module Streaming.Produce
-  ( yield
+  ( -- * Constructing 'Stream's
+    yield
   , each'
   , unfoldr
   , fromHandle
@@ -40,36 +41,69 @@ import GHC.Stack
 -- # The Stream Constructors
 -------------------------------------------------------------------------------
 
+{-| A singleton stream
+
+>>> stdoutLn $ yield "hello"
+hello
+
+>>> S.sum $ do {yield 1; yield 2; yield 3}
+6 :> ()
+
+-}
 yield :: Control.Monad m => a -> Stream (Of a) m ()
 yield x = Step $ x :> Return ()
+{-# INLINE yield #-}
 
+{- | Stream the elements of a pure, foldable container.
+
+>>> S.print $ each' [1..3]
+1
+2
+3
+
+-}
 each' :: Control.Monad m => [a] -> Stream (Of a) m ()
 each' xs = Prelude.foldr (\a stream -> Step $ a :> stream) (Return ()) xs
+{-# INLINABLE each' #-}
 
+{-| Build a @Stream@ by unfolding steps starting from a seed. In particular note
+    that @S.unfoldr S.next = id@.
+
+-}
 unfoldr :: Control.Monad m =>
   (s #-> m (Either r (Unrestricted a, s))) -> s #-> Stream (Of a) m r
-unfoldr step s = Effect $ step s Control.>>= \case
-  Left r -> return $ Return r
-  Right (Unrestricted a,s') -> return $ Step $ a :> unfoldr step s'
+unfoldr step s = unfoldr' step s
   where
     Builder{..} = monadBuilder
+    unfoldr' :: Control.Monad m =>
+      (s #-> m (Either r (Unrestricted a, s))) -> s #-> Stream (Of a) m r
+    unfoldr' step s = Effect $ step s Control.>>= \case
+      Left r -> return $ Return r
+      Right (Unrestricted a,s') -> return $ Step $ a :> unfoldr step s'
+{-# INLINABLE unfoldr #-}
 
 -- Note: we use the RIO monad from linear base to enforce
 -- the protocol of file handles and file I/O
 fromHandle :: Handle #-> Stream (Of Text) RIO ()
-fromHandle h = do
-  (Unrestricted isEOF, h') <- Control.lift $ hIsEOF h
-  case isEOF of
-    True -> do
-      Control.lift $ hClose h'
-      return ()
-    False -> do
-      (Unrestricted text, h'') <- Control.lift $ hGetLine h'
-      yield text
-      fromHandle h''
+fromHandle h = loop h
   where
     Builder{..} = monadBuilder
+    loop :: Handle #-> Stream (Of Text) RIO ()
+    loop h = do
+      (Unrestricted isEOF, h') <- Control.lift $ hIsEOF h
+      case isEOF of
+        True -> do
+          Control.lift $ hClose h'
+          return ()
+        False -> do
+          (Unrestricted text, h'') <- Control.lift $ hGetLine h'
+          yield text
+          fromHandle h''
+{-# INLINABLE fromHandle #-}
 
+{-| Read the lines of a file given the filename.
+
+-}
 readFile :: FilePath -> Stream (Of Text) RIO ()
 readFile path = do
   handle <- Control.lift $ openFile path System.ReadMode
@@ -77,31 +111,47 @@ readFile path = do
   where
     Builder{..} = monadBuilder
 
+-- | Repeat an element several times.
 replicate :: (HasCallStack, Control.Monad m) => Int -> a -> Stream (Of a) m ()
 replicate n a
   | n < 0 = Prelude.error "Cannot replicate a stream of negative length"
-  | n == 0 = Return ()
-  | otherwise = Effect $ Control.return $ Step $ a :> replicate (n-1) a
+  | otherwise = loop n a
+    where
+      loop :: Control.Monad m => Int -> a -> Stream (Of a) m ()
+      loop n a
+        | n == 0 = Return ()
+        | otherwise = Effect $ Control.return $ Step $ a :> loop (n-1) a
+{-# INLINABLE replicate #-}
 
+{-| Repeat an action several times, streaming its results.
+
+-}
 replicateM :: Control.Monad m =>
   Int -> m (Unrestricted a) -> Stream (Of a) m ()
 replicateM n ma
   | n < 0 = Prelude.error "Cannot replicate a stream of negative length"
-  | n == 0 = Return ()
-  | otherwise = Effect $ do
-    Unrestricted a <- ma
-    return $ Step $ a :> (replicateM (n-1) ma)
+  | otherwise = loop n ma
     where
-      Builder{..} = monadBuilder
+      loop :: Control.Monad m => Int -> m (Unrestricted a) -> Stream (Of a) m ()
+      loop n ma
+        | n == 0 = Return ()
+        | otherwise = Effect $ do
+          Unrestricted a <- ma
+          return $ Step $ a :> (replicateM (n-1) ma)
+          where
+            Builder{..} = monadBuilder
 
-untilRight :: Control.Monad m =>
+untilRight :: forall m a r . Control.Monad m =>
   m (Either (Unrestricted a) r) -> Stream (Of a) m r
-untilRight mEither = Effect $ do
-  either <- mEither
-  either & \case
-    Left (Unrestricted a) ->
-      return $ Step $ a :> (untilRight mEither)
-    Right r -> return $ Return r
+untilRight mEither = Effect loop
   where
     Builder{..} = monadBuilder
+    loop :: m (Stream (Of a) m r)
+    loop = do
+      either <- mEither
+      either & \case
+        Left (Unrestricted a) ->
+          return $ Step $ a :> (untilRight mEither)
+        Right r -> return $ Return r
+{-# INLINABLE untilRight #-}
 

--- a/src/Streaming/Type.hs
+++ b/src/Streaming/Type.hs
@@ -8,7 +8,9 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Streaming.Type
-  ( Stream (..)
+  ( -- * The 'Stream' and 'Of' types
+    -- $stream
+    Stream (..)
   , Of (..)
   ) where
 
@@ -21,11 +23,35 @@ import Prelude.Linear (($), (.))
 -- # Data Definitions
 -------------------------------------------------------------------------------
 
+
+{- $stream
+
+    The 'Stream' data type is equivalent to @FreeT@ and can represent any effectful
+    succession of steps, where the form of the steps or 'commands' is
+    specified by the first (functor) parameter. The effects are performed
+    exactly once since the monad is a @Control.Monad@ from
+    <https://github.com/tweag/linear-base linear-base>.
+
+> data Stream f m r = Step !(f (Stream f m r)) | Effect (m (Stream f m r)) | Return r
+
+    The /producer/ concept uses the simple functor @ (a,_) @ \- or the stricter
+    @ Of a _ @. Then the news at each step or layer is just: an individual item of type @a@.
+    Since @Stream (Of a) m r@ is equivalent to @Pipe.Producer a m r@, much of
+    the @pipes@ @Prelude@ can easily be mirrored in a @streaming@ @Prelude@. Similarly,
+    a simple @Consumer a m r@ or @Parser a m r@ concept arises when the base functor is
+    @ (a -> _) @ . @Stream ((->) input) m result@ consumes @input@ until it returns a
+    @result@.
+
+    To avoid breaking reasoning principles, the constructors
+    should not be used directly. A pattern-match should go by way of 'inspect' \
+    \- or, in the producer case, 'Streaming.Prelude.next'
+-}
 data Stream f m r where
   Step :: !(f (Stream f m r)) #-> Stream f m r
   Effect :: m (Stream f m r) #-> Stream f m r
   Return :: r #-> Stream f m r
 
+-- | A left-strict pair; the base functor for streams of individual elements.
 data Of a b where
   (:>) :: !a -> b #-> Of a b
 
@@ -49,41 +75,67 @@ type CMonad = Control.Monad
 instance (DFunctor m, DFunctor f) => Data.Functor (Stream f m) where
   fmap :: (DFunctor m, DFunctor f) =>
     (a #-> b) -> Stream f m a #-> Stream f m b
-  fmap f (Return r) = Return (f r)
-  fmap f (Step fs) = Step $ Data.fmap (Data.fmap f) fs
-  fmap f (Effect ms) = Effect $ Data.fmap (Data.fmap f) ms
+  fmap f s = fmap' f s
+  {-# INLINABLE fmap #-}
+
+fmap' :: (DFunctor m, DFunctor f) =>
+  (a #-> b) -> Stream f m a #-> Stream f m b
+fmap' f (Return r) = Return (f r)
+fmap' f (Step fs) = Step $ Data.fmap (Data.fmap f) fs
+fmap' f (Effect ms) = Effect $ Data.fmap (Data.fmap f) ms
 
 -- Note: the 'CFunctor f' instance is needed. Weaker constraints won't do.
 instance (CFunctor m, CFunctor f) => Data.Applicative (Stream f m) where
   pure :: a -> Stream f m a
   pure = Return
+  {-# INLINE pure #-}
 
   (<*>) :: (CFunctor m, CFunctor f) =>
     Stream f m (a #-> b) #-> Stream f m a #-> Stream f m b
-  (Return f) <*> stream = Control.fmap f stream
-  (Step fs) <*> stream = Step $ Control.fmap (Data.<*> stream) fs
-  (Effect ms) <*> stream = Effect $ Control.fmap (Data.<*> stream) ms
+  (<*>) s1 s2 = app s1 s2
+  {-# INLINABLE (<*>) #-}
+
+app :: (CFunctor m, CFunctor f) =>
+  Stream f m (a #-> b) #-> Stream f m a #-> Stream f m b
+app (Return f) stream = Control.fmap f stream
+app (Step fs) stream = Step $ Control.fmap (Data.<*> stream) fs
+app (Effect ms) stream = Effect $ Control.fmap (Data.<*> stream) ms
+
+
 
 instance (CFunctor m, CFunctor f) => Control.Functor (Stream f m) where
-  fmap :: (CFunctor m, CFunctor f) =>
+  fmap :: (DFunctor m, DFunctor f) =>
     (a #-> b) #-> Stream f m a #-> Stream f m b
-  fmap f (Return r) = Return (f r)
-  fmap f (Step fs) = Step $ Control.fmap (Control.fmap f) fs
-  fmap f (Effect ms) = Effect $ Control.fmap (Control.fmap f) ms
+  fmap f s = fmap'' f s
+  {-# INLINABLE fmap #-}
+
+fmap'' :: (CFunctor m, CFunctor f) =>
+  (a #-> b) #-> Stream f m a #-> Stream f m b
+fmap'' f (Return r) = Return (f r)
+fmap'' f (Step fs) = Step $ Control.fmap (Control.fmap f) fs
+fmap'' f (Effect ms) = Effect $ Control.fmap (Control.fmap f) ms
+
 
 instance (CFunctor m, CFunctor f) => Control.Applicative (Stream f m) where
   pure :: a #-> Stream f m a
   pure = Return
+  {-# INLINE pure #-}
 
   (<*>) :: (CFunctor m, CFunctor f) =>
     Stream f m (a #-> b) #-> Stream f m a #-> Stream f m b
   (<*>) = (Data.<*>)
+  {-# INLINE (<*>) #-}
 
 instance (CFunctor m, CFunctor f) => Control.Monad (Stream f m) where
   (>>=) :: Stream f m a #-> (a #-> Stream f m b) #-> Stream f m b
-  (Return a) >>= f = f a
-  (Step fs) >>= f = Step $ Control.fmap (Control.>>= f) fs
-  (Effect ms) >>= f = Effect $ Control.fmap (Control.>>= f) ms
+  (>>=) = bind
+  {-# INLINABLE (>>=) #-}
+
+bind :: (CFunctor m, CFunctor f) =>
+  Stream f m a #-> (a #-> Stream f m b) #-> Stream f m b
+bind (Return a) f = f a
+bind (Step fs) f = Step $ Control.fmap (Control.>>= f) fs
+bind (Effect ms) f = Effect $ Control.fmap (Control.>>= f) ms
 
 
 -- # MonadTrans for (Stream f m)
@@ -92,6 +144,7 @@ instance (CFunctor m, CFunctor f) => Control.Monad (Stream f m) where
 instance Control.Functor f => Control.MonadTrans (Stream f) where
   lift :: (CFunctor m, CFunctor f) => m a #-> Stream f m a
   lift = Effect . Control.fmap Control.return
+  {-# INLINE lift #-}
 
 
 -- # Control.Functor for (Of)
@@ -99,10 +152,13 @@ instance Control.Functor f => Control.MonadTrans (Stream f) where
 
 ofFmap :: (a #-> b) #-> (Of x a) #-> (Of x b)
 ofFmap f (a :> b) = a :> f b
+{-# INLINE ofFmap #-}
 
 instance Data.Functor (Of a) where
   fmap = Linear.forget ofFmap
+  {-# INLINE fmap #-}
 
 instance Control.Functor (Of a) where
   fmap = ofFmap
+  {-# INLINE fmap #-}
 


### PR DESCRIPTION
This PR adds cut-and-pasted documentation with minor changes along side adding in optimizations. 

This PR depends on #19 .

# Notes

- The changes in the haddock are trivial like renaming `Monad` to `Control.Monad` or adding a sentence to the top-level haddock stating the monad is a control monad from linear base.
- The optimizations just move the code to an inner `loop` function (when needed) and add inline pragmas
- The files left to work through are Process.hs and Consume.hs.
- The non-trivial documentation that needs to be added is deferred to a later PR