### PR TITLE
Having sensible printing primitives

### DIFF
--- a/src/Streaming/Prelude.hs
+++ b/src/Streaming/Prelude.hs
@@ -17,6 +17,12 @@
 > import Streaming
 > import qualified Streaming.Prelude as S
 
+
+== Notes for the examples
+
+    Many of the examples are kept simple to illustrate the ideas and don't
+    print. These can be made to print by small changes so that they
+    typecheck with `S.print` and `S.stdoutLn`.
     For the examples below, one sometimes needs
 
 > import Streaming.Prelude (each, yield, next, mapped, stdoutLn, stdinLn)
@@ -29,7 +35,9 @@
 > import qualified Pipes.Prelude as P
 > import qualified System.IO as IO
 
-     Here are some correspondences between the types employed here and elsewhere:
+== Corrsepondences to other streaming libraries
+
+  Here are some correspondences between the types employed here and elsewhere:
 
 >               streaming             |            pipes               |       conduit       |  io-streams
 > -------------------------------------------------------------------------------------------------------------------

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ packages:
 
 extra-deps:
   - git: https://github.com/tweag/linear-base.git
-    commit: 5df446e4c8801cd5509837ca3feea77b5ab08850
+    commit: bc95b5d40595226348b99b13815638fabc434230
 
 nix:
   enable: true


### PR DESCRIPTION
This PR  makes the types of printing functions easier to use to avoid common boilerplate:
- `print :: (Show a, Movable r) => Stream (Of a) Linear.IO r #-> System.IO r`
- `stdoutLn :: Movable r => Stream (Of Text) Linear.IO r #-> System.IO r`

Common use cases illustrated in the haddock won't work if the result is `Linear.IO r`:

> `>>>  print $ mapped sum $ chunksof 2 $ each [1,1,1,1,1]`
> 2
> 2
> 1

This, it seems to me, is so common that it makes sense to just make going to `System.IO` the default. (And the same goes for `stdoutLn`.) In the cases that we don't want this, e.g.,

> `>>> rest <- print $ splitAt 1 $ each [1..3]`
> 1
> `>>> print rest`
> 2
> 3

we can use `print' :: Show a => Stream (Of a) IO r #-> IO r` with `runLinearIO :: Movable a => Linear.IO a #-> System.IO a` (something I'll implement in linear-base) like so:

> `>>> runLinearIO $ Control.do`
> `  rest <- print' $ splitAt 1 $ each [1..3]`
> `  fromSystemIO (putStr "\n")`
>  `  print' rest`
> 1
>
> 2
> 3


I didn't change all of the haddock that doesn't print currently because it would take too long and make things messier. (I've stashed some of that work [here](https://github.com/tweag/linear-streams/tree/stashing-some-printfriendly-stuff), if we want to use it.) Instead, I've just changed some of the doc to mention that the examples don't print for simplicity and readability but can be made to print with simple changes to work with `print`, `stdoutLn` and `runSystemIO`.