### PR TITLE
Optimizations and documentation with slight or substantial changes

### DIFF
--- a/src/Streaming/Produce.hs
+++ b/src/Streaming/Produce.hs
@@ -125,6 +125,13 @@ replicate n a
 
 {-| Repeat an action several times, streaming its results.
 
+>>> import qualified Unsafe.Linear as Unsafe
+>>> import qualified Data.Time as Time
+>>> let getCurrentTime = fromSystemIO (Unsafe.coerce Time.getCurrentTime)
+>>> S.print $ S.replicateM 2 getCurrentTime
+2015-08-18 00:57:36.124508 UTC
+2015-08-18 00:57:36.124785 UTC
+
 -}
 replicateM :: Control.Monad m =>
   Int -> m (Unrestricted a) -> Stream (Of a) m ()


### PR DESCRIPTION
- I changed line 328 of `Streaming.hs` in the documentation of `mapped` to typecheck and work
- I adapted `hoistExposed` to be the optimized version in the library (should have done this from the get-go, don't know why I chose to re-write it)
- Removed bound checking from `splitAt` so it could be optimized nicely
- Adapted and added the documentation of `replicateM` so it type checks

This, with what it depends on, closes #5 and closes #3.

Depends on #22.