### PR TITLE
Infinite stream workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,52 @@ This change requires the `f` to have a `Control.Monad.Linear.Functor` instance
 and a `Control.Monad` instance for any `Stream f m` with appropriate `m` and `f`.
 In general, all changes are necessarily implied from just changing the `m`.
 
+### Replacing infinite streams like `stdinLn`
+
+We can't have functions like `stdinLn` that produce infinite streams.
+Any function that linearly consumes a @Stream (Of a) m r@ where the @m@
+is a control monad, would have to consume the entire stream. Hence,
+for some @f :: Stream (Of a) m r #-> b@, @f stdinLn@ would never terminate.
+
+The infinite stream API in the original library consisted of @never@,
+@repeats@, @repeatsM@, @stdinLn@, @readLn@, @cycle@, @enumFrom@, @enumFromThen@.
+
+The size-delimited replacements of @repeats@ and @repeatsM@ are just @replicates@ and
+@replicatesM@ from the @Streaming@ module.
+
+We replace @never@ with @oneEach@. See the Haddock for how this works.
+
+The rest of the API are constructors that produce an infinite stream possibly
+from some simple arguments. From combing the examples in the Haddock and linked
+to by the haddock, three common use cases emerge:
+
+ 1. Taking some finite amount:
+
+ `stdoutLn$ doSomething $ take 3 $ stdinLn`
+
+ 2. Taking until a condition is met:
+
+ `highLowGame n = void $ S.break (== n) (readLn :: Stream (Of Int) m ())`
+
+ 3. Zipping with a finite stream:
+
+  `doSomething $ zip (each' ["first name: ", "last name: ", "nickname: "]) stdinLn`
+
+ 4. Some combination of the above.
+
+We can avoid/replace these cases by having these variants of infinite streams like `stdinLn`:
+
+`stdinLnN :: Int -> Stream (Of Text) IO ()`
+`stdinLnUntil :: (Text -> Bool) -> Stream (Of Text) IO ()`
+`stdinLnUntilM :: (Text -> IO Bool) -> Stream (Of Text) IO ()`
+`stdinLnZip :: (Stream (Of a) m ()) #-> Stream (Of (a, Text)) IO ()`
+
+This approach is adopted for the rest of the API and the postfixes
+`N`, `Until`, `UntilM` and `Zip` are followed. We don't need `Until*` functions
+for `replicate`, `cycle`, `enumFrom` and `enumFromThen` since these streams are simple
+enough that a test function doesn't make sense; we can predict each element so there's no
+cause to test until a condition is met.
+
 ### Terminology
 
  * If the monad of the stream is a normal monad, we call the stream an

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ In general, all changes are necessarily implied from just changing the `m`.
 We can't have functions like `stdinLn` that produce infinite streams.
 Any function that linearly consumes a @Stream (Of a) m r@ where the @m@
 is a control monad, would have to consume the entire stream. Hence,
-for some @f :: Stream (Of a) m r #-> b@, @f stdinLn@ would never terminate.
+for some @f :: Stream (Of a) m r #-> B@, @f stdinLn@ would never terminate.
+Hence, we need workarounds for the original API.
 
 The infinite stream API in the original library consisted of @never@,
 @repeats@, @repeatsM@, @stdinLn@, @readLn@, @cycle@, @enumFrom@, @enumFromThen@.
@@ -69,8 +70,8 @@ The size-delimited replacements of @repeats@ and @repeatsM@ are just @replicates
 
 We replace @never@ with @oneEach@. See the Haddock for how this works.
 
-The rest of the API are constructors that produce an infinite stream possibly
-from some simple arguments. From combing the examples in the Haddock and linked
+The rest of the API are constructors that produce an infinite streams @Of@ elements
+possibly from some simple arguments. From combing the examples in the Haddock and linked
 to by the haddock, three common use cases emerge:
 
  1. Taking some finite amount:
@@ -87,7 +88,8 @@ to by the haddock, three common use cases emerge:
 
  4. Some combination of the above.
 
-We can avoid/replace these cases by having these variants of infinite streams like `stdinLn`:
+We can avoid/replace these cases by having these variants of infinite
+streams like `stdinLn`:
 
 `stdinLnN :: Int -> Stream (Of Text) IO ()`
 `stdinLnUntil :: (Text -> Bool) -> Stream (Of Text) IO ()`

--- a/src/Streaming.hs
+++ b/src/Streaming.hs
@@ -15,6 +15,7 @@ module Streaming
   , effect
   , wrap
   , replicates
+  , replicatesM
   , unfold
   , untilJust
   , streamBuild
@@ -183,7 +184,6 @@ wrap = Step
 
 {- | Repeat a functorial layer, command or instruction a fixed number of times.
 
-> replicates n = takes n . repeats
 -}
 replicates :: (HasCallStack, Control.Monad m, Control.Functor f) =>
   Int -> f () -> Stream f m ()
@@ -196,6 +196,25 @@ replicates n f = replicates' n f
       EQ -> Return ()
       GT -> Step $ Control.fmap (\() -> replicates (n-1) f) f
 {-# INLINE replicates #-}
+
+-- Note: The original API has a @repeats@ that creates an infinite stream.
+-- We can't replicated this in the functor-general case but can provide a
+-- @replicatesM@ which is a size delimited @repeatsM@. The treatment when
+-- the functor is specialized to @Of@ is much more careful and works in
+-- the vast majority of cases. See the readme for more.
+
+-- | @replicatesM n@ repeats an effect containing a functorial layer, command
+-- or instruction @n@ times.
+replicatesM :: forall f m . (Control.Monad m, Control.Functor f) =>
+  Int -> m (f ()) -> Stream f m ()
+replicatesM = loop
+  where
+    loop :: Int -> m (f ()) -> Stream f m ()
+    loop n mfstep
+      | n <= 0 = Return ()
+      | Prelude.otherwise = Effect $
+          Control.fmap (Step . Control.fmap (\() -> loop (n-1) mfstep)) mfstep
+{-# INLINABLE replicatesM #-}
 
 unfold :: (Control.Monad m, Control.Functor f) =>
   (s #-> m (Either r (f s))) -> s #-> Stream f m r


### PR DESCRIPTION
This PR adds workarounds for the infinite streaming API from the original library. The infinite stream API in the original library consisted of `never`, `repeats`, `repeatsM`, `stdinLn`, `readLn`, `cycle`, `enumFrom`, `enumFromThen`. Depends on #29.

Documentation for how we replace this API is found in changes to the README.md, cut and paste here at the bottom of this description. Basically, I found that we either (1) took a finite amount of elements from an infinite stream, (2) zipped the infinite stream with a finite stream, or (3) ran the infinite stream until a boolean test succeeded, or some combination of the above. I saw that these were the uses throughout the haddock in [Streaming.Prelude](http://hackage.haskell.org/package/streaming-0.2.3.0/docs/Streaming-Prelude.html) and throughout the [examples of use](https://github.com/haskell-streaming/streaming#-8-where-can-i-find-examples-of-use). So, I just added versions of infinite streams like `stdinLn` with the postfixes `N` (given an int, give a stream of that length), `Until` (a boolean test works) and `Zip` (given a finite stream as the first argument, zip with that stream).

Cut and paste readme changes:

> ### Replacing infinite streams like `stdinLn`
> 
> We can't have functions like `stdinLn` that produce infinite streams.
> Any function that linearly consumes a @Stream (Of a) m r@ where the @m@
> is a control monad, would have to consume the entire stream. Hence,
> for some @f :: Stream (Of a) m r #-> B@, @f stdinLn@ would never terminate.
> Hence, we need workarounds for the original API.
> 
> The infinite stream API in the original library consisted of @never@,
> @repeats@, @repeatsM@, @stdinLn@, @readLn@, @cycle@, @enumFrom@, @enumFromThen@.
> 
> The size-delimited replacements of @repeats@ and @repeatsM@ are just @replicates@ and
> @replicatesM@ from the @Streaming@ module.
> 
> We replace @never@ with @oneEach@. See the Haddock for how this works.
> 
> The rest of the API are constructors that produce an infinite streams @Of@ elements
> possibly from some simple arguments. From combing the examples in the Haddock and linked
> to by the haddock, three common use cases emerge:
> 
>  1. Taking some finite amount:
> 
>  `stdoutLn$ doSomething $ take 3 $ stdinLn`
> 
>  2. Taking until a condition is met:
> 
>  `highLowGame n = void $ S.break (== n) (readLn :: Stream (Of Int) m ())`
> 
>  3. Zipping with a finite stream:
> 
>   `doSomething $ zip (each' ["first name: ", "last name: ", "nickname: "]) stdinLn`
> 
>  4. Some combination of the above.
> 
> We can avoid/replace these cases by having these variants of infinite
> streams like `stdinLn`:
> 
> `stdinLnN :: Int -> Stream (Of Text) IO ()`
> `stdinLnUntil :: (Text -> Bool) -> Stream (Of Text) IO ()`
> `stdinLnUntilM :: (Text -> IO Bool) -> Stream (Of Text) IO ()`
> `stdinLnZip :: (Stream (Of a) m ()) #-> Stream (Of (a, Text)) IO ()`
> 
> This approach is adopted for the rest of the API and the postfixes
> `N`, `Until`, `UntilM` and `Zip` are followed. We don't need `Until*` functions
> for `replicate`, `cycle`, `enumFrom` and `enumFromThen` since these streams are simple
> enough that a test function doesn't make sense; we can predict each element so there's no
> cause to test until a condition is met.
> 